### PR TITLE
Upgraded calls to libsodium library for version 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "psr-4": { "Macaroons\\": "lib/Macaroons" }
   },
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=7.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/lib/Macaroons/Macaroon.php
+++ b/lib/Macaroons/Macaroon.php
@@ -75,13 +75,13 @@ class Macaroon
     $derivedCaveatKey = Utils::truncateOrPad( Utils::generateDerivedKey($caveatKey) );
     $truncatedOrPaddedSignature = Utils::truncateOrPad( $this->signature );
     // Generate cipher using libsodium
-    $nonce = \Sodium\randombytes_buf(\Sodium\CRYPTO_SECRETBOX_NONCEBYTES);
-    $verificationId = $nonce . \Sodium\crypto_secretbox($derivedCaveatKey, $nonce, $truncatedOrPaddedSignature);
+    $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+    $verificationId = $nonce . sodium_crypto_secretbox($derivedCaveatKey, $nonce, $truncatedOrPaddedSignature);
     array_push($this->caveats, new Caveat($caveatId, $verificationId, $caveatLocation));
     $this->signature = Utils::signThirdPartyCaveat($this->signature, $verificationId, $caveatId);
-    \Sodium\memzero($caveatKey);
-    \Sodium\memzero($derivedCaveatKey);
-    \Sodium\memzero($caveatId);
+    sodium_memzero($caveatKey);
+    sodium_memzero($derivedCaveatKey);
+    sodium_memzero($caveatId);
   }
 
   /**

--- a/lib/Macaroons/Verifier.php
+++ b/lib/Macaroons/Verifier.php
@@ -201,10 +201,10 @@ class Verifier
   private function extractCaveatKey($signature, Caveat $caveat)
   {
     $verificationHash = $caveat->getVerificationId();
-    $nonce            = substr($verificationHash, 0, \Sodium\CRYPTO_SECRETBOX_NONCEBYTES);
-    $verificationId   = substr($verificationHash, \Sodium\CRYPTO_SECRETBOX_NONCEBYTES);
+    $nonce            = substr($verificationHash, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+    $verificationId   = substr($verificationHash, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
     $key              = Utils::truncateOrPad($signature);
-    return \Sodium\crypto_secretbox_open($verificationId, $nonce, $key);
+    return sodium_crypto_secretbox_open($verificationId, $nonce, $key);
   }
 
   /**


### PR DESCRIPTION
PHP 7.2 includes Libsodium 2.x which has a backward incompatible interface